### PR TITLE
vdsc: generalize deploy script to multi cluster

### DIFF
--- a/image-specifications/vdsc/scripts/add_network.py
+++ b/image-specifications/vdsc/scripts/add_network.py
@@ -1,13 +1,19 @@
 #!/bin/python
-from vdsm import vdscli
+from vdsm import client
 import socket
 
-c = vdscli.connect()
+c = client.connect('localhost')
+ip_addr = socket.gethostbyname(socket.gethostname())
+gateway_addr = '{0}.{1}'.format('.'.join(ip_addr.split('.')[:3]), '1')
 network_attrs = {'nic': 'veth_name0',
-                 'ipaddr': socket.gethostbyname(socket.gethostname()),
+                 'ipaddr': ip_addr,
                  'netmask': '255.240.0.0',
-                 'gateway': '172.17.0.1',
+                 'gateway': gateway_addr,
                  'defaultRoute': True,
                  'bridged': True}
 
-c.setupNetworks({'ovirtmgmt': network_attrs}, {}, {'connectivityCheck': False})
+c.Host.setupNetworks(
+    networks={'ovirtmgmt': network_attrs},
+    bondings={},
+    options={'connectivityCheck': False}
+)


### PR DESCRIPTION
We have different pod IP's for the local and multicluster
environments, also we miss cluster route.